### PR TITLE
Update gradle.yml to remove dependency-submission job

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -55,21 +55,21 @@ jobs:
     # - name: Build with Gradle 8.5
     #   run: gradle build
 
-  dependency-submission:
-
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
+#  dependency-submission:
+#
+#    runs-on: ubuntu-latest
+#    permissions:
+#      contents: write
+#
+#    steps:
+#    - uses: actions/checkout@v4
+#    - name: Set up JDK 17
+#      uses: actions/setup-java@v4
+#      with:
+#        java-version: '17'
+#        distribution: 'temurin'
 
     # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
     # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
-    - name: Generate and submit dependency graph
-      uses: gradle/actions/dependency-submission@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+#    - name: Generate and submit dependency graph
+#      uses: gradle/actions/dependency-submission@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -37,7 +37,7 @@ jobs:
     # TODO: Remove when published to maven central!!!
     - name: Fetch up-client-android-java
       run: |
-        git clone https://github.com/eclipse-uprotocol/up-client-android-java.git
+        git clone --branch v0.1.0-dev https://github.com/eclipse-uprotocol/up-client-android-java.git
         cd up-client-android-java
         ./gradlew publishToMavenLocal
 


### PR DESCRIPTION
The dependency submission job requires write access but the project is not at a state that we need to generate these artifacts so we are disabling the job for now.