### PR TITLE
Pull up-client-android-java from GitHub repo

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,13 +34,6 @@ jobs:
       uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
 
 
-    # TODO: Remove when published to maven central!!!
-    - name: Fetch up-client-android-java
-      run: |
-        git clone --branch v0.1.0-dev https://github.com/eclipse-uprotocol/up-client-android-java.git
-        cd up-client-android-java
-        ./gradlew publishToMavenLocal
-
     - name: Build with Gradle Wrapper
       run: ./gradlew build
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ mockito = "4.6.1"
 robolectric = "4.7.3"
 room = "2.4.2"
 room-testing = "1.1.1"
-up-client-android-java = "1.5.+"
+up-client-android-java = "v0.1.0-dev"
 up-java = "1.5.8"
 
 [libraries]
@@ -37,7 +37,7 @@ robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectr
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
 room-testing = { module = "android.arch.persistence.room:testing", version.ref = "room-testing" }
-up-client-android-java = { module = "org.eclipse.uprotocol:up-client-android-java", version.ref = "up-client-android-java" }
+up-client-android-java = { module = "com.github.eclipse-uprotocol:up-client-android-java", version.ref = "up-client-android-java" }
 up-java = { module = "org.eclipse.uprotocol:up-java", version.ref = "up-java" }
 
 [plugins]

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,6 +14,7 @@ pluginManagement {
         google()
         mavenCentral()
         gradlePluginPortal()
+        maven { url 'https://jitpack.io' }
     }
 }
 
@@ -23,6 +24,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         mavenLocal()
+        maven { url 'https://jitpack.io' }
     }
 }
 


### PR DESCRIPTION
This commit pulls the `up-client-android-java` repository from GitHub using the release tag `v0.1.0-dev`. The release tag ensures that the codebase is at a specific version.